### PR TITLE
refactor(eventual-send): staged

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -139,7 +139,7 @@ const makeE = HandledPromise => {
        *
        * @template T
        * @param {T} x target for method/function call
-       * @returns {import('./index').ECallableOrMethods<import('./index').RemoteFunctions<T>>} method/function call proxy
+       * @returns {ECallableOrMethods<import('./index').RemoteFunctions<T>>} method/function call proxy
        */
       x => harden(new Proxy(() => {}, makeEProxyHandler(x, HandledPromise))),
       {
@@ -151,7 +151,7 @@ const makeE = HandledPromise => {
          *
          * @template T
          * @param {T} x target for property get
-         * @returns {import('./index').EGetters<import('./index').LocalRecord<T>>} property get proxy
+         * @returns {EGetters<import('./index').LocalRecord<T>>} property get proxy
          * @readonly
          */
         get: x =>
@@ -179,7 +179,7 @@ const makeE = HandledPromise => {
          *
          * @template T
          * @param {T} x target for method/function call
-         * @returns {import('./index').ESendOnlyCallableOrMethods<import('./index').RemoteFunctions<T>>} method/function call proxy
+         * @returns {ESendOnlyCallableOrMethods<import('./index').RemoteFunctions<T>>} method/function call proxy
          * @readonly
          */
         sendOnly: x =>
@@ -194,8 +194,8 @@ const makeE = HandledPromise => {
          * @template T
          * @template [U = T]
          * @param {T|PromiseLike<T>} x value to convert to a handled promise
-         * @param {(value: T) => import('./index').ERef<U>} [onfulfilled]
-         * @param {(reason: any) => import('./index').ERef<U>} [onrejected]
+         * @param {(value: T) => ERef<U>} [onfulfilled]
+         * @param {(reason: any) => ERef<U>} [onrejected]
          * @returns {Promise<U>}
          * @readonly
          */
@@ -224,7 +224,7 @@ export default makeE;
  *
  * @template Primary The type of the primary reference.
  * @template [Local=DataOnly<Primary>] The local properties of the object.
- * @typedef {import('./index').ERef<Local & import('./E').RemotableBrand<Local, Primary>>} FarRef
+ * @typedef {ERef<Local & import('./E').RemotableBrand<Local, Primary>>} FarRef
  */
 
 /**
@@ -236,5 +236,46 @@ export default makeE;
  */
 
 /**
+ * @see {@link https://github.com/microsoft/TypeScript/issues/31394}
+ * @template T
+ * @typedef {PromiseLike<T> | T} ERef
+ */
+
+/**
  * @typedef {ReturnType<makeE>} EProxy
+ */
+
+/**
+ * @template {import('./index').Callable} T
+ * @typedef {ReturnType<T> extends PromiseLike<infer U> ? T : (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>} ECallable
+ */
+
+/**
+ * @template T
+ * @typedef {{ readonly [P in keyof T]: T[P] extends import('./index').Callable ? ECallable<T[P]> : never; }} EMethods
+ */
+
+/**
+ * @template T
+ * @typedef {{ readonly [P in keyof T]: T[P] extends PromiseLike<infer U> ? T[P] : Promise<Awaited<T[P]>>; }} EGetters
+ */
+
+/**
+ * @template {import('./index').Callable} T
+ * @typedef {(...args: Parameters<T>) => Promise<void>} ESendOnlyCallable
+ */
+
+/**
+ * @template T
+ * @typedef {{ readonly [P in keyof T]: T[P] extends import('./index').Callable ? ESendOnlyCallable<T[P]> : never; }} ESendOnlyMethods
+ */
+
+/**
+ * @template T
+ * @typedef {T extends import('./index').Callable ? ESendOnlyCallable<T> & ESendOnlyMethods<Required<T>> : ESendOnlyMethods<Required<T>>} ESendOnlyCallableOrMethods
+ */
+
+/**
+ * @template T
+ * @typedef {T extends import('./index').Callable ? ECallable<T> & EMethods<Required<T>> : EMethods<Required<T>>} ECallableOrMethods
  */

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,6 +1,7 @@
 import { trackTurns } from './track-turns.js';
 
 const { details: X, quote: q, Fail } = assert;
+const { assign } = Object;
 
 /** @type {ProxyHandler<any>} */
 const baseFreezableProxyHandler = {
@@ -34,10 +35,10 @@ const baseFreezableProxyHandler = {
  * @param {import('./index').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
-function EProxyHandler(x, HandledPromise) {
-  return harden({
+const makeEProxyHandler = (x, HandledPromise) =>
+  harden({
     ...baseFreezableProxyHandler,
-    get(_target, p, receiver) {
+    get: (_target, p, receiver) => {
       return harden(
         {
           // This function purposely checks the `this` value (see above)
@@ -60,15 +61,14 @@ function EProxyHandler(x, HandledPromise) {
         }[p],
       );
     },
-    apply(_target, _thisArg, argArray = []) {
+    apply: (_target, _thisArg, argArray = []) => {
       return HandledPromise.applyFunction(x, argArray);
     },
-    has(_target, _p) {
+    has: (_target, _p) => {
       // We just pretend everything exists.
       return true;
     },
   });
-}
 
 /**
  * A Proxy handler for E.sendOnly(x)
@@ -78,10 +78,10 @@ function EProxyHandler(x, HandledPromise) {
  * @param {import('./index').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
-function EsendOnlyProxyHandler(x, HandledPromise) {
-  return harden({
+const makeESendOnlyProxyHandler = (x, HandledPromise) =>
+  harden({
     ...baseFreezableProxyHandler,
-    get(_target, p, receiver) {
+    get: (_target, p, receiver) => {
       return harden(
         {
           // This function purposely checks the `this` value (see above)
@@ -101,49 +101,140 @@ function EsendOnlyProxyHandler(x, HandledPromise) {
         }[p],
       );
     },
-    apply(_target, _thisArg, argsArray = []) {
+    apply: (_target, _thisArg, argsArray = []) => {
       HandledPromise.applyFunctionSendOnly(x, argsArray);
       return undefined;
     },
-    has(_target, _p) {
+    has: (_target, _p) => {
       // We just pretend that everything exists.
       return true;
     },
   });
-}
+
+/**
+ * A Proxy handler for E.get(x)
+ * It is a variant on the E(x) Proxy handler.
+ *
+ * @param {*} x Any value passed to E.get(x)
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
+ * @returns {ProxyHandler} the Proxy handler
+ */
+const makeEGetProxyHandler = (x, HandledPromise) =>
+  harden({
+    ...baseFreezableProxyHandler,
+    has: (_target, _prop) => true,
+    get: (_target, prop) => HandledPromise.get(x, prop),
+  });
 
 /**
  * @param {import('./index').HandledPromiseConstructor} HandledPromise
- * @returns {import('./index').EProxy}
  */
-export default function makeE(HandledPromise) {
-  function E(x) {
-    const handler = EProxyHandler(x, HandledPromise);
-    return harden(new Proxy(() => {}, handler));
-  }
+const makeE = HandledPromise => {
+  return harden(
+    assign(
+      /**
+       * E(x) returns a proxy on which you can call arbitrary methods. Each of these
+       * method calls returns a promise. The method will be invoked on whatever
+       * 'x' designates (or resolves to) in a future turn, not this one.
+       *
+       * @template T
+       * @param {T} x target for method/function call
+       * @returns {import('./index').ECallableOrMethods<import('./index').RemoteFunctions<T>>} method/function call proxy
+       */
+      x => harden(new Proxy(() => {}, makeEProxyHandler(x, HandledPromise))),
+      {
+        /**
+         * E.get(x) returns a proxy on which you can get arbitrary properties.
+         * Each of these properties returns a promise for the property.  The promise
+         * value will be the property fetched from whatever 'x' designates (or
+         * resolves to) in a future turn, not this one.
+         *
+         * @template T
+         * @param {T} x target for property get
+         * @returns {import('./index').EGetters<import('./index').LocalRecord<T>>} property get proxy
+         * @readonly
+         */
+        get: x =>
+          harden(
+            new Proxy(
+              Object.create(null),
+              makeEGetProxyHandler(x, HandledPromise),
+            ),
+          ),
 
-  const makeEGetterProxy = x =>
-    new Proxy(Object.create(null), {
-      ...baseFreezableProxyHandler,
-      has(_target, _prop) {
-        return true;
+        /**
+         * E.resolve(x) converts x to a handled promise. It is
+         * shorthand for HandledPromise.resolve(x)
+         *
+         * @template T
+         * @param {T} x value to convert to a handled promise
+         * @returns {Promise<Awaited<T>>} handled promise for x
+         * @readonly
+         */
+        resolve: HandledPromise.resolve,
+
+        /**
+         * E.sendOnly returns a proxy similar to E, but for which the results
+         * are ignored (undefined is returned).
+         *
+         * @template T
+         * @param {T} x target for method/function call
+         * @returns {import('./index').ESendOnlyCallableOrMethods<import('./index').RemoteFunctions<T>>} method/function call proxy
+         * @readonly
+         */
+        sendOnly: x =>
+          harden(
+            new Proxy(() => {}, makeESendOnlyProxyHandler(x, HandledPromise)),
+          ),
+
+        /**
+         * E.when(x, res, rej) is equivalent to
+         * HandledPromise.resolve(x).then(res, rej)
+         *
+         * @template T
+         * @template [U = T]
+         * @param {T|PromiseLike<T>} x value to convert to a handled promise
+         * @param {(value: T) => import('./index').ERef<U>} [onfulfilled]
+         * @param {(reason: any) => import('./index').ERef<U>} [onrejected]
+         * @returns {Promise<U>}
+         * @readonly
+         */
+        when: (x, onfulfilled, onrejected) =>
+          HandledPromise.resolve(x).then(
+            ...trackTurns([onfulfilled, onrejected]),
+          ),
       },
-      get(_target, prop) {
-        return HandledPromise.get(x, prop);
-      },
-    });
+    ),
+  );
+};
 
-  E.get = makeEGetterProxy;
-  E.resolve = HandledPromise.resolve;
-  E.sendOnly = x => {
-    const handler = EsendOnlyProxyHandler(x, HandledPromise);
-    return harden(new Proxy(() => {}, handler));
-  };
+export default makeE;
 
-  E.when = (x, onfulfilled, onrejected) => {
-    const [onsuccess, onfailure] = trackTurns([onfulfilled, onrejected]);
-    return HandledPromise.resolve(x).then(onsuccess, onfailure);
-  };
+/**
+ * Nominal type to carry the local and remote interfaces of a Remotable.
+ *
+ * @template Local The local properties of the object.
+ * @template Remote The type of all the remotely-callable functions.
+ * @typedef {{ constructor?: new (...args: RemotableBrand<Local, Remote>[]) => RemotableBrand<Local, Remote> }} RemotableBrand
+ */
 
-  return harden(E);
-}
+/**
+ * Creates a type that accepts both near and marshalled references that were
+ * returned from `Remotable` or `Far`, and also promises for such references.
+ *
+ * @template Primary The type of the primary reference.
+ * @template [Local=DataOnly<Primary>] The local properties of the object.
+ * @typedef {import('./index').ERef<Local & import('./E').RemotableBrand<Local, Primary>>} FarRef
+ */
+
+/**
+ * `DataOnly<T>` means to return a record type `T2` consisting only of
+ * properties that are *not* functions.
+ *
+ * @template T The type to be filtered.
+ * @typedef {Omit<T, import('./index').FilteredKeys<T, import('./index').Callable>>} DataOnly
+ */
+
+/**
+ * @typedef {ReturnType<makeE>} EProxy
+ */

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -232,7 +232,7 @@ export default makeE;
  * properties that are *not* functions.
  *
  * @template T The type to be filtered.
- * @typedef {Omit<T, import('./index').FilteredKeys<T, import('./index').Callable>>} DataOnly
+ * @typedef {Omit<T, import('./index').FilteredKeys<T, import('./types').Callable>>} DataOnly
  */
 
 /**
@@ -246,13 +246,13 @@ export default makeE;
  */
 
 /**
- * @template {import('./index').Callable} T
+ * @template {import('./types').Callable} T
  * @typedef {ReturnType<T> extends PromiseLike<infer U> ? T : (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>} ECallable
  */
 
 /**
  * @template T
- * @typedef {{ readonly [P in keyof T]: T[P] extends import('./index').Callable ? ECallable<T[P]> : never; }} EMethods
+ * @typedef {{ readonly [P in keyof T]: T[P] extends import('./types').Callable ? ECallable<T[P]> : never; }} EMethods
  */
 
 /**
@@ -261,21 +261,69 @@ export default makeE;
  */
 
 /**
- * @template {import('./index').Callable} T
+ * @template {import('./types').Callable} T
  * @typedef {(...args: Parameters<T>) => Promise<void>} ESendOnlyCallable
  */
 
 /**
  * @template T
- * @typedef {{ readonly [P in keyof T]: T[P] extends import('./index').Callable ? ESendOnlyCallable<T[P]> : never; }} ESendOnlyMethods
+ * @typedef {{ readonly [P in keyof T]: T[P] extends import('./types').Callable ? ESendOnlyCallable<T[P]> : never; }} ESendOnlyMethods
  */
 
 /**
  * @template T
- * @typedef {T extends import('./index').Callable ? ESendOnlyCallable<T> & ESendOnlyMethods<Required<T>> : ESendOnlyMethods<Required<T>>} ESendOnlyCallableOrMethods
+ * @typedef {T extends import('./types').Callable ? ESendOnlyCallable<T> & ESendOnlyMethods<Required<T>> : ESendOnlyMethods<Required<T>>} ESendOnlyCallableOrMethods
  */
 
 /**
  * @template T
- * @typedef {T extends import('./index').Callable ? ECallable<T> & EMethods<Required<T>> : EMethods<Required<T>>} ECallableOrMethods
+ * @typedef {T extends import('./types').Callable ? ECallable<T> & EMethods<Required<T>> : EMethods<Required<T>>} ECallableOrMethods
+ */
+
+/**
+ * Return a union of property names/symbols/numbers P for which the record element T[P]'s type extends U.
+ *
+ * Given const x = { a: 123, b: 'hello', c: 42, 49: () => {}, 53: 67 },
+ *
+ * FilteredKeys<typeof x, number> is the type 'a' | 'c' | 53.
+ * FilteredKeys<typeof x, string> is the type 'b'.
+ * FilteredKeys<typeof x, 42 | 67> is the type 'c' | 53.
+ * FilteredKeys<typeof x, boolean> is the type never.
+ *
+ * @template T
+ * @template U
+ * @typedef {{[P in keyof T]: T[P] extends U ? P : never;}[keyof T]} FilteredKeys
+ */
+
+/**
+ * `PickCallable<T>` means to return a single root callable or a record type
+ * consisting only of properties that are functions.
+ *
+ * @template T
+ * @typedef {T extends import('./types').Callable ? (...args: Parameters<T>) => ReturnType<T> : Pick<T, FilteredKeys<T, import('./types').Callable>>} PickCallable
+ */
+
+/**
+ * `RemoteFunctions<T>` means to return the functions and properties that are remotely callable.
+ *
+ * @template T
+ * @typedef {T extends RemotableBrand<infer L, infer R> ? import('./index').PickCallable<R> : Awaited<T> extends RemotableBrand<infer L, infer R> ? import('./index').PickCallable<R> : T extends PromiseLike<infer U> ? Awaited<T> : T} RemoteFunctions
+ */
+
+/**
+ * @template T
+ * @typedef {T extends RemotableBrand<infer L, infer R> ? L : Awaited<T> extends RemotableBrand<infer L, infer R> ? L : T extends PromiseLike<infer U> ? Awaited<T> : T} LocalRecord
+ */
+
+/**
+ * @template {unknown} R
+ * @typedef {{promise: Promise<R>, settler: import('./handled-promise.js').Settler<R>}} EPromiseKit
+ */
+
+/**
+ * Type for an object that must only be invoked with E.  It supports a given
+ * interface but declares all the functions as asyncable.
+ *
+ * @template T
+ * @typedef {T extends (...args: infer P) => infer R ? (...args: P) => Promise<R> : T extends Record<PropertyKey, import('./types').Callable> ? { [K in keyof T]: T[K] extends import('./types').Callable ? (...args: Parameters<T[K]>) => Promise<ReturnType<T[K]>> : T[K] } : T} EOnly
  */

--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -12,10 +12,10 @@ const { Fail, details: X, quote: q } = assert;
 
 /**
  * @template T
- * @typedef {import('.').EHandler<T>} EHandler
+ * @typedef {import('./index').EHandler<T>} EHandler
  */
 
-/** @typedef {import('.').HandledPromiseConstructor} HandledPromiseConstructor */
+/** @typedef {import('./index').HandledPromiseConstructor} HandledPromiseConstructor */
 
 const {
   create,
@@ -203,7 +203,7 @@ export const makeHandledPromise = () => {
    * This *needs* to be a `function X` so that we can use it as a constructor.
    *
    * @template R
-   * @param {import('.').HandledExecutor<R>} executor
+   * @param {import('./index').HandledExecutor<R>} executor
    * @param {EHandler<Promise<R>>} [pendingHandler]
    * @returns {Promise<R>}
    */
@@ -398,7 +398,7 @@ export const makeHandledPromise = () => {
     );
   };
 
-  /** @type {import('.').HandledPromiseStaticMethods & Pick<PromiseConstructor, 'resolve'>} */
+  /** @type {import('./index').HandledPromiseStaticMethods & Pick<PromiseConstructor, 'resolve'>} */
   const staticMethods = {
     get(target, prop) {
       prop = coerceToObjectProperty(prop);

--- a/packages/eventual-send/src/handled-promise.js
+++ b/packages/eventual-send/src/handled-promise.js
@@ -112,14 +112,14 @@ export const makeHandledPromise = () => {
    * This special handler accepts Promises, and forwards
    * handled Promises to their corresponding fulfilledHandler.
    *
-   * @type {Required<import('./index').EHandler<any>>}
+   * @type {Required<Handler<any>>}
    */
   let forwardingHandler;
   let handle;
 
   /**
    * @param {string} handlerName
-   * @param {import('./index').EHandler<any>} handler
+   * @param {Handler<any>} handler
    * @param {string} operation
    * @param {any} o
    * @param {any[]} opArgs
@@ -189,7 +189,7 @@ export const makeHandledPromise = () => {
     );
   };
 
-  /** @typedef {{new <R>(executor: HandledExecutor<R>, unfulfilledHandler?: import('./index').EHandler<Promise<unknown>>): Promise<R>, prototype: Promise<unknown>} & PromiseConstructor & import('./index').HandledPromiseStaticMethods} HandledPromiseConstructor */
+  /** @typedef {{new <R>(executor: HandledExecutor<R>, unfulfilledHandler?: Handler<Promise<unknown>>): Promise<R>, prototype: Promise<unknown>} & PromiseConstructor & HandledPromiseStaticMethods} HandledPromiseConstructor */
   /** @type {HandledPromiseConstructor} */
   let HandledPromise;
 
@@ -197,8 +197,8 @@ export const makeHandledPromise = () => {
    * This *needs* to be a `function X` so that we can use it as a constructor.
    *
    * @template R
-   * @param {import('./index').HandledExecutor<R>} executor
-   * @param {import('./index').EHandler<Promise<R>>} [pendingHandler]
+   * @param {HandledExecutor<R>} executor
+   * @param {Handler<Promise<R>>} [pendingHandler]
    * @returns {Promise<R>}
    */
   function baseHandledPromise(executor, pendingHandler = undefined) {
@@ -392,7 +392,7 @@ export const makeHandledPromise = () => {
     );
   };
 
-  /** @type {import('./index').HandledPromiseStaticMethods & Pick<PromiseConstructor, 'resolve'>} */
+  /** @type {HandledPromiseStaticMethods & Pick<PromiseConstructor, 'resolve'>} */
   const staticMethods = {
     get(target, prop) {
       prop = coerceToObjectProperty(prop);
@@ -581,38 +581,54 @@ export const makeHandledPromise = () => {
 
 /**
  * @template T
- * @typedef {object} Handler
- * @property {(p: T, name: PropertyKey, returnedP?: Promise<unknown>) => unknown} [get]
- * @property {(p: T, name: PropertyKey) => void} [getSendOnly]
- * @property {(p: T, args: unknown[], returnedP?: Promise<unknown>) => unknown} [applyFunction]
- * @property {(p: T, args: unknown[]) => void} [applyFunctionSendOnly]
- * @property {(p: T, name: PropertyKey | undefined, args: unknown[], returnedP?: Promise<unknown>) => unknown} [applyMethod]
- * @property {(p: T, name: PropertyKey | undefined, args: unknown[]) => void} [applyMethodSendOnly]
+ * @typedef {{
+ *   get?(p: T, name: PropertyKey, returnedP?: Promise<unknown>): unknown;
+ *   getSendOnly?(p: T, name: PropertyKey): void;
+ *   applyFunction?(p: T, args: unknown[], returnedP?: Promise<unknown>): unknown;
+ *   applyFunctionSendOnly?(p: T, args: unknown[]): void;
+ *   applyMethod?(p: T, name: PropertyKey | undefined, args: unknown[], returnedP?: Promise<unknown>): unknown;
+ *   applyMethodSendOnly?(p: T, name: PropertyKey | undefined, args: unknown[]): void;
+ * }} Handler
  */
 
 /**
  * @template {{}} T
- * @typedef {{proxy?: {handler: ProxyHandler<T>, target: unknown, revokerCallback?: (revoker: () => void) => void} } } ResolveWithPresenceOptionsBag
+ * @typedef {{
+ *   proxy?: {
+ *     handler: ProxyHandler<T>;
+ *     target: unknown;
+ *     revokerCallback?(revoker: () => void): void;
+ *   };
+ * }} ResolveWithPresenceOptionsBag
  */
 
 /**
  * @template {unknown} R
- * @typedef {(resolveHandled: (value?: R) => void, rejectHandled: (reason?: unknown) => void, resolveWithPresence: ( presenceHandler: import('./index').EHandler<{}>, options?: import('./index').ResolveWithPresenceOptionsBag<{}>, ) => object ) => void} HandledExecutor
+ * @typedef {(
+ *   resolveHandled: (value?: R) => void,
+ *   rejectHandled: (reason?: unknown) => void,
+ *   resolveWithPresence: (presenceHandler: Handler<{}>, options?: ResolveWithPresenceOptionsBag<{}>) => object,
+ * ) => void} HandledExecutor
  */
 
 /**
  * @template {unknown} R
- * @typedef {{resolve: (value?: R) => void, reject: (reason: unknown) => void, resolveWithPresence: (presenceHandler?: import('./index').EHandler<{}>, options?: import('./index').ResolveWithPresenceOptionsBag<{}> ) => object}} Settler
+ * @typedef {{
+ *   resolve(value?: R): void;
+ *   reject(reason: unknown): void;
+ *   resolveWithPresence(presenceHandler?: Handler<{}>, options?: ResolveWithPresenceOptionsBag<{}>): object;
+ * }} Settler
  */
 
 /**
- * @typedef {object} HandledPromiseStaticMethods
- * @property {(target: unknown, args: unknown[])=> Promise<unknown>} applyFunction
- * @property {(target: unknown, args: unknown[])=> void} applyFunctionSendOnly
- * @property {(target: unknown, prop: PropertyKey | undefined, args: unknown[])=> Promise<unknown>} applyMethod
- * @property {(target: unknown, prop: PropertyKey, args: unknown[])=> void} applyMethodSendOnly
- * @property {(target: unknown, prop: PropertyKey)=> Promise<unknown>} get
- * @property {(target: unknown, prop: PropertyKey)=> void} getSendOnly
+ * @typedef {{
+ *   applyFunction(target: unknown, args: unknown[]): Promise<unknown>;
+ *   applyFunctionSendOnly(target: unknown, args: unknown[]): void;
+ *   applyMethod(target: unknown, prop: PropertyKey | undefined, args: unknown[]): Promise<unknown>;
+ *   applyMethodSendOnly(target: unknown, prop: PropertyKey, args: unknown[]): void;
+ *   get(target: unknown, prop: PropertyKey): Promise<unknown>;
+ *   getSendOnly(target: unknown, prop: PropertyKey): void;
+ * }} HandledPromiseStaticMethods
  */
 
 /** @typedef {ReturnType<makeHandledPromise>} HandledPromiseConstructor */

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -13,6 +13,7 @@ import * as _E from './E.js';
 export import RemotableBrand = _E.RemotableBrand;
 export import DataOnly = _E.DataOnly;
 export import FarRef = _E.FarRef;
+export import ERef = _E.ERef;
 export import EProxy = _E.EProxy;
 
 // Type definitions for eventual-send
@@ -42,9 +43,6 @@ export import EProxy = _E.EProxy;
  */
 
 export type Callable = (...args: any[]) => any;
-
-// Same as https://github.com/microsoft/TypeScript/issues/31394
-export type ERef<T> = PromiseLike<T> | T;
 
 export declare const EmptyObj: {};
 
@@ -184,50 +182,5 @@ declare namespace global {
 }
 
 export declare const HandledPromise: HandledPromiseConstructor;
-
-/**
- * "E" short for "Eventual", what we call something that has to return a promise.
- */
-type ECallable<T extends Callable> = ReturnType<T> extends PromiseLike<infer U>
-  ? T // function already returns a promise
-  : (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>; // make it return a promise
-
-/* Types for E proxy calls. */
-
-/**
- * Transform each function in T to return a promise
- */
-type EMethods<T> = {
-  readonly [P in keyof T]: T[P] extends Callable ? ECallable<T[P]> : never;
-};
-
-type ECallableOrMethods<T> = T extends Callable
-  ? ECallable<T> & EMethods<Required<T>>
-  : EMethods<Required<T>>;
-
-type EGetters<T> = {
-  readonly [P in keyof T]: T[P] extends PromiseLike<infer U>
-    ? T[P]
-    : Promise<Awaited<T[P]>>;
-};
-
-/* Same types for send-only. */
-type ESendOnlyCallable<T extends Callable> = (
-  ...args: Parameters<T>
-) => Promise<void>;
-
-type ESendOnlyMethods<T> = {
-  readonly [P in keyof T]: T[P] extends Callable
-    ? ESendOnlyCallable<T[P]>
-    : never;
-};
-
-type ESendOnlyCallableOrMethods<T> = T extends Callable
-  ? ESendOnlyCallable<T> & ESendOnlyMethods<Required<T>>
-  : ESendOnlyMethods<Required<T>>;
-
-interface ESendOnly {
-  <T>(x: T): ESendOnlyCallableOrMethods<RemoteFunctions<T>>;
-}
 
 export const E: EProxy;

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -1,3 +1,20 @@
+import * as _E from './E.js';
+
+// Exposing types directly per the jsdoc annotations and comments.
+//
+//   See: https://grep.app/search?q=%5E%20%2A%28export%20%2B%29import%20%2A%5Cw%2B%20%2A%3D&regexp=true&filter[repo][0]=microsoft/TypeScript&filter[path][0]=tests/
+//
+//   Note: Some types will not include the jsdoc docs, but
+//         those still propagate for the source entities of
+//         the respective annotations. Types exported below
+//         are intended for type-checking against decoupled
+//         references between packages.
+
+export import RemotableBrand = _E.RemotableBrand;
+export import DataOnly = _E.DataOnly;
+export import FarRef = _E.FarRef;
+export import EProxy = _E.EProxy;
+
 // Type definitions for eventual-send
 
 /**
@@ -54,28 +71,6 @@ export type EOnly<T> = T extends (...args: infer P) => infer R
 export type FilteredKeys<T, U> = {
   [P in keyof T]: T[P] extends U ? P : never;
 }[keyof T];
-
-/**
- * `DataOnly<T>` means to return a record type `T2` consisting only of properties that are *not* functions.
- */
-export type DataOnly<T> = Omit<T, FilteredKeys<T, Callable>>;
-
-// Nominal type to carry the local and remote interfaces of a Remotable.
-export declare class RemotableBrand<L, R> {
-  // The local properties of the object.
-  private localProperties: L;
-
-  // The type of all the remotely-callable functions.
-  private remoteCallable: R;
-}
-
-/**
- * Creates a type that accepts both near and marshalled references that were
- * returned from `Remotable` or `Far`, and also promises for such references.
- */
-export type FarRef<Primary, Local = DataOnly<Primary>> = ERef<
-  Local & RemotableBrand<Local, Primary>
->;
 
 /**
  * `PickCallable<T>` means to return a single root callable or a record type
@@ -233,53 +228,6 @@ type ESendOnlyCallableOrMethods<T> = T extends Callable
 
 interface ESendOnly {
   <T>(x: T): ESendOnlyCallableOrMethods<RemoteFunctions<T>>;
-}
-
-// Generic on the proxy target {T}
-interface EProxy {
-  /**
-   * E(x) returns a proxy on which you can call arbitrary methods. Each of
-   * these method calls returns a promise. The method will be invoked on
-   * whatever 'x' designates (or resolves to) in a future turn, not this
-   * one.
-   *
-   * @param x target for method/function call
-   * @returns method/function call proxy
-   */
-  <T>(x: T): ECallableOrMethods<RemoteFunctions<T>>;
-
-  /**
-   * E.get(x) returns a proxy on which you can get arbitrary properties.
-   * Each of these properties returns a promise for the property.  The promise
-   * value will be the property fetched from whatever 'x' designates (or
-   * resolves to) in a future turn, not this one.
-   *
-   * @param x target for property get
-   * @returns property get proxy
-   */
-  readonly get: <T>(x: T) => EGetters<LocalRecord<T>>;
-
-  /**
-   * E.resolve(x) converts x to a handled promise. It is
-   * shorthand for HandledPromise.resolve(x)
-   */
-  readonly resolve: <T>(x: T) => Promise<Awaited<T>>;
-
-  /**
-   * E.when(x, res, rej) is equivalent to
-   * HandledPromise.resolve(x).then(res, rej)
-   */
-  readonly when: <T, U = Awaited<T>>(
-    x: T,
-    onfulfilled?: (value: Awaited<T>) => ERef<U>,
-    onrejected?: (reason: any) => ERef<U>,
-  ) => Promise<U>;
-
-  /**
-   * E.sendOnly returns a proxy similar to E, but for which the results
-   * are ignored (undefined is returned).
-   */
-  readonly sendOnly: ESendOnly;
 }
 
 export const E: EProxy;

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -1,6 +1,4 @@
-import * as _E from './E.js';
-import * as _HandledPromise from './handled-promise.js';
-import * as _Postponed from './postponed.js';
+import type { HandledPromiseConstructor, EProxy } from './types.d';
 
 // Exposing types directly per the jsdoc annotations and comments.
 //
@@ -12,51 +10,25 @@ import * as _Postponed from './postponed.js';
 //         are intended for type-checking against decoupled
 //         references between packages.
 
-export import RemotableBrand = _E.RemotableBrand;
-export import DataOnly = _E.DataOnly;
-export import FarRef = _E.FarRef;
-export import ERef = _E.ERef;
-export import EProxy = _E.EProxy;
-export import EOnly = _E.EOnly;
-export import RemoteFunctions = _E.RemoteFunctions;
-export import LocalRecord = _E.LocalRecord;
-export import FilteredKeys = _E.FilteredKeys;
-export import PickCallable = _E.PickCallable;
-export import RemoteKit = _E.EPromiseKit;
-
-export import ResolveWithPresenceOptionsBag = _HandledPromise.ResolveWithPresenceOptionsBag;
-export import HandledExecutor = _HandledPromise.HandledExecutor;
-export import Settler = _HandledPromise.Settler;
-export import HandledPromiseStaticMethods = _HandledPromise.HandledPromiseStaticMethods;
-export import HandledPromiseConstructor = _HandledPromise.HandledPromiseConstructor;
-
-export import EHandler = _HandledPromise.Handler;
-
-// Type definitions for eventual-send
-
-/**
- * @file Type definitions for @agoric/eventual-send
- *
- * Some useful background knowledge:
- *
- * `Omit<T, U>` means to return a record type `T2` which has none of the properties whose keys are part of `U`.
- * `Omit<{a: 1, b: 2, c: 3}, 'b'>` is the type `{a: 1, c: 3}`.
- *
- * `Pick<T, U>` means to return a record type `T2` which has only the properties whose keys are part of `U`.
- * `Pick<{a: 1, b: 2, c: 3}, 'b'>` is the type `{b: 2}`.
- *
- * `PromiseLike<T>` is a thenable which resolves to `T`.
- *
- * `Promise<PromiseLike<T>>` doesn't handle recursion and is distinct from `T`.
- *
- * `Unpromise<PromiseLike<T>>` strips off just one layer and is just `T`.  `Unpromise<PromiseLike<PromiseLIke<T>>` is `PromiseLike<T>`.
- *
- * `Awaited<PromiseLike<T>>` recurses, and is just `T`.
- * `Awaited<PromiseLike<PromiseLike<T>>>` is just `T` as well.
- *
- * @see {@link https://www.typescriptlang.org/docs/handbook/2/generics.html#handbook-content}
- * @see {@link https://www.typescriptlang.org/docs/handbook/2/conditional-types.html}
- */
+export type {
+  RemotableBrand,
+  DataOnly,
+  FarRef,
+  ERef,
+  EProxy,
+  EOnly,
+  RemoteFunctions,
+  LocalRecord,
+  FilteredKeys,
+  PickCallable,
+  EPromiseKit as RemoteKit,
+  ResolveWithPresenceOptionsBag,
+  HandledExecutor,
+  Settler,
+  HandledPromiseStaticMethods,
+  HandledPromiseConstructor,
+  Handler as EHandler,
+} from './types.d';
 
 declare namespace global {
   // eslint-disable-next-line vars-on-top,no-var

--- a/packages/eventual-send/src/index.test-d.ts
+++ b/packages/eventual-send/src/index.test-d.ts
@@ -1,12 +1,7 @@
 /* eslint-disable @endo/no-polymorphic-call, import/no-extraneous-dependencies, no-restricted-globals */
 import { expectType } from 'tsd';
 import { E } from '../test/get-hp.js';
-import { DataOnly, ERef } from './index.js';
-
-type FarRef<
-  Primary,
-  Local = DataOnly<Primary>,
-> = import('@endo/eventual-send').FarRef<Primary, Local>;
+import { ERef, FarRef } from './index.d';
 
 // Check the legacy ERef type
 const foo = async (a: ERef<{ bar(): string; baz: number }>) => {

--- a/packages/eventual-send/src/postponed.js
+++ b/packages/eventual-send/src/postponed.js
@@ -2,14 +2,14 @@
 
 /**
  * @template T
- * @typedef {import('.').EHandler<T>} EHandler
+ * @typedef {import('./index').EHandler<T>} EHandler
  */
 
 /**
  * Create a simple postponedHandler that just postpones until donePostponing is
  * called.
  *
- * @param {import('.').HandledPromiseConstructor} HandledPromise
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
  * @returns {[Required<EHandler<any>>, () => void]} A pair consisting of the
  * postponedHandler and donePostponing callback.
  */

--- a/packages/eventual-send/src/postponed.js
+++ b/packages/eventual-send/src/postponed.js
@@ -1,17 +1,11 @@
 /// <reference types="ses" />
 
 /**
- * @template T
- * @typedef {import('./index').EHandler<T>} EHandler
- */
-
-/**
  * Create a simple postponedHandler that just postpones until donePostponing is
  * called.
  *
  * @param {import('./index').HandledPromiseConstructor} HandledPromise
- * @returns {[Required<EHandler<any>>, () => void]} A pair consisting of the
- * postponedHandler and donePostponing callback.
+ * @returns {[import('./index').EHandler<any>, () => void]} postponedHandler and donePostponing callback.
  */
 export const makePostponedHandler = HandledPromise => {
   let donePostponing;
@@ -33,7 +27,7 @@ export const makePostponedHandler = HandledPromise => {
     };
   };
 
-  /** @type {Required<EHandler<any>>} */
+  /** @type {Required<import('./index').EHandler<any>>} */
   const postponedHandler = {
     get: makePostponedOperation('get'),
     getSendOnly: makePostponedOperation('getSendOnly'),

--- a/packages/eventual-send/src/postponed.js
+++ b/packages/eventual-send/src/postponed.js
@@ -4,11 +4,13 @@
  * Create a simple postponedHandler that just postpones until donePostponing is
  * called.
  *
- * @param {import('./index').HandledPromiseConstructor} HandledPromise
- * @returns {[import('./index').EHandler<any>, () => void]} postponedHandler and donePostponing callback.
+ * @param {import('./types').HandledPromiseConstructor} HandledPromise
+ * @returns {[Required<import('./types').Handler<any>>, () => void]} postponedHandler and donePostponing callback.
  */
 export const makePostponedHandler = HandledPromise => {
+  /** @type {() => void} */
   let donePostponing;
+
   const interlockP = new Promise(resolve => {
     donePostponing = () => resolve(undefined);
   });
@@ -27,7 +29,7 @@ export const makePostponedHandler = HandledPromise => {
     };
   };
 
-  /** @type {Required<import('./index').EHandler<any>>} */
+  /** @type {Required<import('./types').Handler<any>>} */
   const postponedHandler = {
     get: makePostponedOperation('get'),
     getSendOnly: makePostponedOperation('getSendOnly'),
@@ -37,6 +39,8 @@ export const makePostponedHandler = HandledPromise => {
     applyMethodSendOnly: makePostponedOperation('applyMethodSendOnly'),
   };
 
+  // @ts-expect-error 2454
   assert(donePostponing);
+
   return [postponedHandler, donePostponing];
 };

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -1,5 +1,4 @@
 /* global globalThis */
-// @ts-nocheck
 
 const { freeze } = Object;
 
@@ -80,13 +79,6 @@ const wrapFunction =
   };
 
 /**
- * @typedef {((...args: any[]) => any) | undefined} TurnStarterFn
- * An optional function that is not this-sensitive, expected to be called at
- * bottom of stack to start a new turn.
- */
-
-/**
- * @template {TurnStarterFn[]} T
  * Given a list of `TurnStarterFn`s, returns a list of `TurnStarterFn`s whose
  * `this`-free call behaviors are not observably different to those that
  * cannot see console output. The only purpose is to cause additional
@@ -97,6 +89,7 @@ const wrapFunction =
  * to any of the returned `TurnStartFn`s is a receiving event that begins a new
  * turn. This sending event caused each of those receiving events.
  *
+ * @template {TurnStarterFn[]} T
  * @param {T} funcs
  * @returns {T}
  */
@@ -114,5 +107,14 @@ export const trackTurns = funcs => {
     assert.note(sendingError, X`Caused by: ${hiddenPriorError}`);
   }
 
-  return funcs.map(func => func && wrapFunction(func, sendingError, X));
+  return /** @type {T} */ (
+    funcs.map(func => func && wrapFunction(func, sendingError, X))
+  );
 };
+
+/**
+ * An optional function that is not this-sensitive, expected to be called at
+ * bottom of stack to start a new turn.
+ *
+ * @typedef {((...args: any[]) => any) | undefined} TurnStarterFn
+ */

--- a/packages/eventual-send/src/types.d.ts
+++ b/packages/eventual-send/src/types.d.ts
@@ -1,0 +1,1 @@
+export type Callable = (...args: any[]) => any;

--- a/packages/eventual-send/src/types.d.ts
+++ b/packages/eventual-send/src/types.d.ts
@@ -1,1 +1,14 @@
-export type Callable = (...args: any[]) => any;
+/* eslint-disable import/export */
+
+// Module Types //////////////////////////////////////////////////////
+
+// @ts-ignore TS1383: Only named exports may use 'export type'.
+export type * from './E.js';
+// @ts-ignore TS1383: Only named exports may use 'export type'.
+export type * from './handled-promise.js';
+// @ts-ignore TS1383: Only named exports may use 'export type'.
+export type * from './track-turns.js';
+
+// Utility Types /////////////////////////////////////////////////////
+
+export type Callable = (...args: unknown[]) => any;

--- a/packages/eventual-send/src/types.test.ts
+++ b/packages/eventual-send/src/types.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @endo/no-polymorphic-call, import/no-extraneous-dependencies, no-restricted-globals */
+import { E } from '../test/get-hp.js';
+import { ERef, FarRef } from './index.d';
+
+// Check the legacy ERef type
+const foo = async (a: ERef<{ bar(): string; baz: number }>) => {
+  const { baz } = await a;
+
+  E(a).bar() satisfies Promise<string>;
+
+  // Should be type error, but isn't.
+  (await a).bar();
+
+  E.get(a).baz satisfies Promise<number>;
+
+  // Should be type error, but isn't.
+  E.get(a).bar satisfies Promise<() => string>;
+
+  // @ts-expect-error - calling a directly is not typed, but works.
+  a.bar();
+};
+
+// FarRef<T>
+const foo2 = async (a: FarRef<{ bar(): string; baz: number }>) => {
+  const { baz } = await a;
+
+  baz satisfies number;
+
+  E(a).bar() satisfies Promise<string>;
+
+  // @ts-expect-error - awaiting remotes cannot get functions
+  (await a).bar;
+
+  E.get(a).baz satisfies Promise<number>;
+
+  // @ts-expect-error - E.get cannot obtain remote functions
+  E.get(a).bar;
+
+  (await a).baz satisfies number;
+
+  // @ts-expect-error 2339 - calling directly is valid but not yet in the typedef
+  a.bar;
+};
+
+// when
+const aPromise = Promise.resolve('a');
+const onePromise = Promise.resolve(1);
+const remoteString: ERef<string> = Promise.resolve('remote');
+E.when(Promise.all([aPromise, onePromise, remoteString])).then(
+  ([str, num, remote]) => {
+    str satisfies string;
+    num satisfies number;
+    remote satisfies string;
+  },
+);
+E.when(
+  Promise.all([aPromise, onePromise, remoteString]),
+  ([str, num, remote]) => {
+    str satisfies string;
+    num satisfies number;
+    remote satisfies string;
+    return { something: 'new' };
+  },
+).then(result => {
+  result satisfies { something: string };
+});


### PR DESCRIPTION
This will be pushed into #1542 as separate commits.

- [x] Use `import('./types')` instead of `typedef` aliases internally
- [x] Move `HandledPromise`-specific types into `src/handled-promise.js`
- [x] Move utility types into `src/types.d.ts`

**Future Considerations**

- Use `satisfies` instead of `expectType<…>(…)`
  - Rewrite `src/index.test-d.ts` to `src/types.test.ts`
  - Consider using `tsc` instead of `tsd` in `package.json` scripts
- Cleanup `src/index.d.ts` (drop?)